### PR TITLE
[TASK-128] 루트 어드민 알림 기능 

### DIFF
--- a/apps/root-admin/src/app/(dashboard)/festivals/[id]/[concert-id]/page.tsx
+++ b/apps/root-admin/src/app/(dashboard)/festivals/[id]/[concert-id]/page.tsx
@@ -2,10 +2,7 @@ import {
   BreadCrumbs,
   type BreadcrumbList,
   ConcertButtonList,
-  ConcertUpdateForm,
-  DrawerButton,
   LineUpCard,
-  LineupCreateForm,
   OpenHiddenToggle,
 } from '@components';
 import { type Params, cn } from '@swifty/shared-lib';

--- a/apps/root-admin/src/app/layout.tsx
+++ b/apps/root-admin/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { AntdRegistry } from '@ant-design/nextjs-registry';
+import { NotificationProvider } from '@components';
 import { spaceGrotesk } from '@styles/font';
 import '@styles/global.css';
 import '@styles/theme.css';
@@ -39,7 +40,9 @@ export default function RootLayout({
     <html lang="en">
       <body className={spaceGrotesk.className}>
         <AntdRegistry>
-          <ConfigProvider theme={darkTheme}>{children}</ConfigProvider>
+          <ConfigProvider theme={darkTheme}>
+            <NotificationProvider>{children}</NotificationProvider>
+          </ConfigProvider>
         </AntdRegistry>
       </body>
     </html>

--- a/apps/root-admin/src/app/login/page.tsx
+++ b/apps/root-admin/src/app/login/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { NotificationHandlerContext } from '@components';
 import { API_AUTH } from '@lib';
 import { customFetch } from '@swifty/shared-lib';
 import type { FormProps } from 'antd';
 import { Button, Form, Input } from 'antd';
 import { useRouter } from 'next/navigation';
+import { useContext } from 'react';
 
 import styles from './login.module.css';
 
@@ -15,20 +17,29 @@ type FieldType = {
 
 export default function Page() {
   const [form] = Form.useForm();
+  const handleNotification = useContext(NotificationHandlerContext);
   const router = useRouter();
   const onFinish: FormProps<FieldType>['onFinish'] = async (values) => {
-    await customFetch(API_AUTH.login, {
-      method: 'POST',
-      body: JSON.stringify(values),
-    });
-    form.setFieldValue('formId', '');
-    form.setFieldValue('password', '');
-    router.replace('/');
+    try {
+      await customFetch(API_AUTH.login, {
+        method: 'POST',
+        body: JSON.stringify(values),
+      });
+      form.setFieldValue('formId', '');
+      form.setFieldValue('password', '');
+      router.replace('/');
+    } catch (err) {
+      handleNotification(
+        {
+          message: '로그인에 실패하였습니다',
+          description: '다시 시도해주세요!',
+          placement: 'topRight',
+          role: 'alert',
+        },
+        'error',
+      );
+    }
   };
-
-  const onFinishFailed: FormProps<FieldType>['onFinishFailed'] = async (
-    errorInfo,
-  ) => {};
 
   return (
     <main className={styles.main}>
@@ -40,7 +51,6 @@ export default function Page() {
         style={{ maxWidth: 600 }}
         initialValues={{ remember: false }}
         onFinish={onFinish}
-        onFinishFailed={onFinishFailed}
         autoComplete="on"
       >
         <Form.Item<FieldType>

--- a/apps/root-admin/src/components/festival/button/festival-button-list.tsx
+++ b/apps/root-admin/src/components/festival/button/festival-button-list.tsx
@@ -7,12 +7,8 @@ import {
   FestivalUpdateForm,
 } from '@components';
 import { API_FESTIVAL, FETCH_TAG } from '@lib';
-import type {
-  PropsWithClassName} from '@swifty/shared-lib';
-import {
-  customFetch,
-  revalidate,
-} from '@swifty/shared-lib';
+import type { PropsWithClassName } from '@swifty/shared-lib';
+import { customFetch, revalidate } from '@swifty/shared-lib';
 import type { FestivalDetail } from '@type';
 import { Flex } from 'antd';
 import { useRouter } from 'next/navigation';
@@ -26,13 +22,9 @@ export default function FestivalButtonList({
 
   const router = useRouter();
   const onDelet = async () => {
-    try {
-      await customFetch(API_FESTIVAL.delete(subId), { method: 'DELETE' });
-      await revalidate(FETCH_TAG.festivals);
-      router.replace(`/festivals`);
-    } catch (err) {
-      console.error(err);
-    }
+    await customFetch(API_FESTIVAL.delete(subId), { method: 'DELETE' });
+    await revalidate(FETCH_TAG.festivals);
+    router.replace(`/festivals`);
   };
 
   return (

--- a/apps/root-admin/src/components/festival/form/festival-create-form.tsx
+++ b/apps/root-admin/src/components/festival/form/festival-create-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Upload } from '@components';
+import { NotificationHandlerContext, Upload } from '@components';
 import { API_FESTIVAL, FETCH_TAG } from '@lib';
 import { customFetch, revalidate } from '@swifty/shared-lib';
 import type { UploadFile } from 'antd';
@@ -9,7 +9,7 @@ import type { FormInstance, FormProps } from 'antd/lib/form';
 import type { RcFile } from 'antd/lib/upload';
 import dayjs from 'dayjs';
 import 'dayjs/locale/ko';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import overCurrentDay from 'src/lib/util/over-current-day';
 
 const { RangePicker } = DatePicker;
@@ -36,6 +36,7 @@ interface Props {
 export default function FestivalForm({ id, form, onClose }: Props) {
   const [poster, setPoster] = useState<UploadFile[]>([]);
   const [thumbnail, setThumbnail] = useState<UploadFile[]>([]);
+  const handleNotification = useContext(NotificationHandlerContext);
 
   form?.setFieldValue('poster', poster);
   form?.setFieldValue('thumbnail', thumbnail);
@@ -88,7 +89,15 @@ export default function FestivalForm({ id, form, onClose }: Props) {
       setThumbnail([]);
       form?.resetFields();
       onClose?.();
-    } catch (err) {}
+    } catch (err) {
+      handleNotification(
+        {
+          message: '대학  축제 생성에 실패했습니다!',
+          description: (err as Error).message,
+        },
+        'error',
+      );
+    }
   };
   return (
     <Form layout="vertical" form={form} onFinish={onFinish}>

--- a/apps/root-admin/src/components/index.tsx
+++ b/apps/root-admin/src/components/index.tsx
@@ -2,3 +2,4 @@ export * from './festival';
 export * from './ui';
 export * from './university';
 export * from './user';
+export * from './provider';

--- a/apps/root-admin/src/components/provider/index.ts
+++ b/apps/root-admin/src/components/provider/index.ts
@@ -1,0 +1,2 @@
+export { default as NotificationProvider } from './notification-provider';
+export { NotificationHandlerContext } from './notification-provider';

--- a/apps/root-admin/src/components/provider/notification-provider.tsx
+++ b/apps/root-admin/src/components/provider/notification-provider.tsx
@@ -2,13 +2,13 @@
 
 import { notification } from 'antd';
 import type { ArgsProps } from 'antd/lib/notification/interface';
-import type { PropsWithChildren} from 'react';
+import type { PropsWithChildren } from 'react';
 import { createContext, useCallback, useMemo } from 'react';
 
 type NotificationKey = 'success' | 'error' | 'info' | 'warning';
 
 export const NotificationHandlerContext = createContext<
-  (option: ArgsProps, type: NotificationKey) => void
+  (option: ArgsProps, type?: NotificationKey) => void
 >(() => {});
 
 export default function NotificationProvider({ children }: PropsWithChildren) {

--- a/apps/root-admin/src/components/provider/notification-provider.tsx
+++ b/apps/root-admin/src/components/provider/notification-provider.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { notification } from 'antd';
+import type { ArgsProps } from 'antd/lib/notification/interface';
+import type { PropsWithChildren} from 'react';
+import { createContext, useCallback, useMemo } from 'react';
+
+type NotificationKey = 'success' | 'error' | 'info' | 'warning';
+
+export const NotificationHandlerContext = createContext<
+  (option: ArgsProps, type: NotificationKey) => void
+>(() => {});
+
+export default function NotificationProvider({ children }: PropsWithChildren) {
+  const [api, contextHolder] = notification.useNotification();
+
+  const handleNotification = useCallback(
+    (option: ArgsProps, type: NotificationKey = 'success') => {
+      api[type](option);
+    },
+    [api],
+  );
+
+  const memoizedContextHolder = useMemo(() => contextHolder, [contextHolder]);
+  return (
+    <NotificationHandlerContext.Provider value={handleNotification}>
+      {children}
+      {memoizedContextHolder}
+    </NotificationHandlerContext.Provider>
+  );
+}

--- a/apps/root-admin/src/components/ui/button/delete-button/index.tsx
+++ b/apps/root-admin/src/components/ui/button/delete-button/index.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import type { ButtonProps} from 'antd';
+import { NotificationHandlerContext } from '@components';
+import type { ButtonProps } from 'antd';
 import { Button, Popconfirm } from 'antd';
-import type { PropsWithChildren } from 'react';
+import { type PropsWithChildren, useContext } from 'react';
 
 interface Props extends PropsWithChildren {
   title: string;
@@ -18,6 +19,21 @@ export default function DeleteButton({
   children,
   size = 'small',
 }: Props) {
+  const handleNotification = useContext(NotificationHandlerContext);
+  const onDelete = async () => {
+    try {
+      await onConfirm();
+    } catch (err) {
+      handleNotification(
+        {
+          message: '삭제에 실패했습니다.',
+          description: (err as Error).message,
+        },
+        'error',
+      );
+    }
+  };
+
   return (
     <Popconfirm
       title={title}
@@ -25,7 +41,7 @@ export default function DeleteButton({
       okText="확인"
       okType="danger"
       cancelText="취소"
-      onConfirm={onConfirm}
+      onConfirm={onDelete}
     >
       <Button type="primary" danger size={size}>
         {children}

--- a/apps/root-admin/src/components/university/form/university-host-create-form.tsx
+++ b/apps/root-admin/src/components/university/form/university-host-create-form.tsx
@@ -1,12 +1,13 @@
 'use client';
 
+import { NotificationHandlerContext } from '@components';
 import { API_HSOT, FETCH_TAG } from '@lib';
 import { customFetch, revalidate } from '@swifty/shared-lib';
 import type { UniversityHostCreate } from '@type';
 import { Col, Form, Input, Radio, Row } from 'antd';
 import { Modal } from 'antd';
 import type { FormInstance, FormProps } from 'antd/lib/form';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 
 import styles from './university-host-create-form.module.css';
 
@@ -25,6 +26,8 @@ interface Props {
 
 export default function UniversityHostCreateForm({ onClose, form, id }: Props) {
   const [modal, setModal] = useState(false);
+  const handleNotification = useContext(NotificationHandlerContext);
+
   const [hostUserInfo, sethostUserInfo] = useState({
     id: '',
     pw: '',
@@ -56,7 +59,16 @@ export default function UniversityHostCreateForm({ onClose, form, id }: Props) {
       });
       form?.resetFields(['phoneNumber', 'loginId', 'userRole']);
       setModal(true);
-    } catch (err) {}
+    } catch (err) {
+      console.error(err);
+      handleNotification(
+        {
+          message: 'host 유저 생성에 실패하였습니다.',
+          description: (err as Error).message,
+        },
+        'error',
+      );
+    }
   };
   return (
     <>

--- a/apps/root-admin/src/components/university/form/university-update-form.tsx
+++ b/apps/root-admin/src/components/university/form/university-update-form.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { SearchUniversity } from '@components';
+import { NotificationHandlerContext, SearchUniversity } from '@components';
 import { API_UNIVERSITY } from '@lib';
 import { customFetch, revalidate } from '@swifty/shared-lib';
 import type { University } from '@type';
 import { Col, Form, Input, Row } from 'antd';
 import type { FormInstance, FormProps } from 'antd/lib/form';
+import { useContext } from 'react';
 
 type FieldType = {
   name: string;
@@ -24,19 +25,30 @@ export default function UniversityUpdateForm({
   university,
 }: Props) {
   const initialValue = { name: university.name, addr: university.addr };
+  const handleNotification = useContext(NotificationHandlerContext);
 
   const onFinish: FormProps<FieldType>['onFinish'] = async (
     values: FieldType,
   ) => {
-    await customFetch(
-      API_UNIVERSITY.patch_delete_universiry(university.subId),
-      {
-        method: 'PATCH',
-        body: JSON.stringify(values),
-      },
-    );
-    await revalidate('university');
-    onClose?.();
+    try {
+      await customFetch(
+        API_UNIVERSITY.patch_delete_universiry(university.subId),
+        {
+          method: 'PATCH',
+          body: JSON.stringify(values),
+        },
+      );
+      await revalidate('university');
+      onClose?.();
+    } catch (err) {
+      handleNotification(
+        {
+          message: '대학 정보 수정에 실패하였습니다.',
+          description: (err as Error).message,
+        },
+        'error',
+      );
+    }
   };
   return (
     <Form

--- a/apps/root-admin/src/components/user/user-info/user-state-button-list.tsx
+++ b/apps/root-admin/src/components/user/user-info/user-state-button-list.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { DeleteButton } from '@components';
+import { DeleteButton, NotificationHandlerContext } from '@components';
 import { API_CLIENT } from '@lib';
 import { customFetch, revalidate } from '@swifty/shared-lib';
 import type { UserStatus } from '@type';
 import { Button, Popconfirm } from 'antd';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 
 import styles from './userInfo.module.css';
 
@@ -25,6 +25,7 @@ export default function UserStateButtonList({
   const router = useRouter();
   const [errorMessage, setErrorMessage] = useState<null | string>(null);
   const [userStatus, setUserStatus] = useState<UserStatus>(status);
+  const handleNotification = useContext(NotificationHandlerContext);
 
   const changeStatesToUserStatus = (state: States): UserStatus => {
     const upper = state.toUpperCase();
@@ -50,6 +51,13 @@ export default function UserStateButtonList({
         setErrorMessage(`Change ${state.toUpperCase()} : ${err.message}`);
       }
       setUserStatus(prevStatus);
+      handleNotification(
+        {
+          message: 'Error',
+          description: '사용자 상태 변경에 실패했습니다.',
+        },
+        'error',
+      );
     }
   };
 

--- a/apps/root-admin/src/hooks/festival/use-concert-crud.ts
+++ b/apps/root-admin/src/hooks/festival/use-concert-crud.ts
@@ -1,10 +1,11 @@
 'use client';
 
+import { NotificationHandlerContext } from '@components';
 import { API_CONCERT, FETCH_TAG, changeDateFormat } from '@lib';
 import { customFetch, revalidate } from '@swifty/shared-lib';
 import dayjs from 'dayjs';
 import 'dayjs/locale/ko';
-import { useCallback, useState } from 'react';
+import { useCallback, useContext, useState } from 'react';
 
 const FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 
@@ -26,6 +27,7 @@ type UpdateFieldType = {
 export default function useConcertCRUD() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const handleNotification = useContext(NotificationHandlerContext);
 
   const createConcert = useCallback(
     async (festivalSubId: string, values: FieldType) => {
@@ -51,6 +53,13 @@ export default function useConcertCRUD() {
       } catch (e) {
         if (e instanceof Error) setError(e.message);
         else setError('예상치 못한 오류가 발생했습니다.');
+        handleNotification(
+          {
+            message: '콘서트 생성에 실패하였습니다.',
+            description: (e as Error).message,
+          },
+          'error',
+        );
       } finally {
         setIsLoading(false);
       }
@@ -82,6 +91,13 @@ export default function useConcertCRUD() {
       } catch (e) {
         if (e instanceof Error) setError(e.message);
         else setError('예상치 못한 오류가 발생했습니다.');
+        handleNotification(
+          {
+            message: '콘서트 수정에 실패하였습니다.',
+            description: (e as Error).message,
+          },
+          'error',
+        );
       } finally {
         setIsLoading(false);
       }
@@ -100,6 +116,13 @@ export default function useConcertCRUD() {
     } catch (e) {
       if (e instanceof Error) setError(e.message);
       else setError('예상치 못한 오류가 발생했습니다.');
+      handleNotification(
+        {
+          message: '콘서트 삭제에 실패하였습니다.',
+          description: (e as Error).message,
+        },
+        'error',
+      );
     } finally {
       setIsLoading(false);
     }

--- a/apps/root-admin/src/hooks/festival/use-lineup-crud.ts
+++ b/apps/root-admin/src/hooks/festival/use-lineup-crud.ts
@@ -1,12 +1,13 @@
 'use client';
 
+import { NotificationHandlerContext } from '@components';
 import { API_LINEUP } from '@lib';
 import { customFetch } from '@swifty/shared-lib';
 import type { UploadFile } from 'antd';
 import type { RcFile } from 'antd/es/upload';
 import dayjs from 'dayjs';
 import 'dayjs/locale/ko';
-import { useCallback, useState } from 'react';
+import { useCallback, useContext, useState } from 'react';
 
 const FORMAT = 'HH:mm:ss';
 
@@ -19,6 +20,7 @@ type FieldType = {
 export default function useLineupCRUD() {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const handleNotification = useContext(NotificationHandlerContext);
 
   const createLineup = useCallback(
     async (concertSubId: string, values: FieldType, newFile: UploadFile) => {
@@ -52,6 +54,13 @@ export default function useLineupCRUD() {
         } else {
           setError('예상치 못한 오류가 발생했습니다.');
         }
+        handleNotification(
+          {
+            message: '라인업 생성에 실패하였습니다.',
+            description: (e as Error).message,
+          },
+          'error',
+        );
       } finally {
         setIsLoading(false);
       }
@@ -96,6 +105,13 @@ export default function useLineupCRUD() {
       } catch (e) {
         if (e instanceof Error) setError(e.message);
         else setError('예상치 못한 오류가 발생했습니다.');
+        handleNotification(
+          {
+            message: '라인업 수정에 실패하였습니다.',
+            description: (e as Error).message,
+          },
+          'error',
+        );
       } finally {
         setIsLoading(false);
       }
@@ -113,6 +129,13 @@ export default function useLineupCRUD() {
     } catch (e) {
       if (e instanceof Error) setError(e.message);
       else setError('예상치 못한 오류가 발생했습니다.');
+      handleNotification(
+        {
+          message: '라인업 삭제에 실패하였습니다.',
+          description: (e as Error).message,
+        },
+        'error',
+      );
     } finally {
       setIsLoading(false);
     }

--- a/apps/root-admin/src/hooks/use-pagination.ts
+++ b/apps/root-admin/src/hooks/use-pagination.ts
@@ -1,9 +1,10 @@
 'use client';
 
+import { NotificationHandlerContext } from '@components';
 import { customFetch } from '@swifty/shared-lib';
 import type { Paginaiton } from '@type';
 import type { UserRole } from '@type';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 
 interface Prop<T> {
   pageSize: number;
@@ -24,18 +25,31 @@ export default function usePagination<T>({
     total,
   });
   const [loading, setLoading] = useState(false);
+  const handleNotification = useContext(NotificationHandlerContext);
 
   // 페이지 변경에 따른 데이터 업데이트
   const handleTableChange = async (page: number, pageSize: number) => {
     setLoading(true);
-    const data = await customFetch<Paginaiton<T>>(api(page - 1, pageSize));
-    setTableData(data.content);
-    setPagination({
-      ...pagination,
-      current: page,
-      pageSize,
-    });
-    setLoading(false);
+    try {
+      const data = await customFetch<Paginaiton<T>>(api(page - 1, pageSize));
+      setTableData(data.content);
+      setPagination({
+        ...pagination,
+        current: page,
+        pageSize,
+      });
+    } catch (err) {
+      handleNotification(
+        {
+          message: 'page를 불러오는 것에 실패했습니다!',
+          description: '다시 시도해주세요!',
+          placement: 'topRight',
+        },
+        'error',
+      );
+    } finally {
+      setLoading(false);
+    }
   };
   return { pagination, loading, handleTableChange };
 }


### PR DESCRIPTION
- Close : #24 
- [antd-notification](https://ant.design/components/notification)을 참고해서 기능을 구현했습니다. 
- components의 procider 탭에서 구현을 확인할 수 있습니다. notification을 활성화 하는 함수를 컨텍스트에 저장하고 이를 활용하는 방식입니다. 해당 함수 호출로 쉽게 notification을 활용할 수 있습니다.
```ts
'use client';

import { notification } from 'antd';
import type { ArgsProps } from 'antd/lib/notification/interface';
import type { PropsWithChildren} from 'react';
import { createContext, useCallback, useMemo } from 'react';

type NotificationKey = 'success' | 'error' | 'info' | 'warning';

export const NotificationHandlerContext = createContext<
  (option: ArgsProps, type: NotificationKey) => void
>(() => {});

export default function NotificationProvider({ children }: PropsWithChildren) {
  const [api, contextHolder] = notification.useNotification();

  const handleNotification = useCallback(
    (option: ArgsProps, type: NotificationKey = 'success') => {
      api[type](option);
    },
    [api],
  );

  const memoizedContextHolder = useMemo(() => contextHolder, [contextHolder]);
  return (
    <NotificationHandlerContext.Provider value={handleNotification}>
      {children}
      {memoizedContextHolder}
    </NotificationHandlerContext.Provider>
  );
}

``